### PR TITLE
Apply link color from mdx-deck base theme

### DIFF
--- a/example/topics/new-features.mdx
+++ b/example/topics/new-features.mdx
@@ -6,8 +6,10 @@ export default Section
 
 ---
 > Hello World
-> 
+>
 > -- <cite>Dustin Schau</cite>
+
+[Link to Gatsby](//www.gatsbyjs.org)
 ---
 
 ## List items

--- a/src/gatsby-mdx-theme.js
+++ b/src/gatsby-mdx-theme.js
@@ -13,7 +13,7 @@ export default {
   transitionTimingFunction: 'linear',
   transitionDuration: '0s',
   colors: {
-    background: 'white',
+    ...theme.colors,
     heading: colors.gatsby
   },
   blockquote: {


### PR DESCRIPTION
> From [suggestion in `theming.md` of `mdx-deck`](https://github.com/jxnblk/mdx-deck/blob/4af7d225ef85b0a3bd8f82e88ed249d1fc7e2916/docs/theming.md#custom-themes) we can reuse link color from [base theme of mdx-deck](https://github.com/jxnblk/mdx-deck/blob/4af7d225ef/src/themes/base.js#L10)

Also, link example is added by _my own opinion_ which is definitely open for changes

<img width="354" alt="screen shot 2019-01-16 at 16 01 04" src="https://user-images.githubusercontent.com/4994705/51234542-f9a3b880-19a7-11e9-9541-d3dad080a848.png">
